### PR TITLE
altered startup of cli script

### DIFF
--- a/install/setup.sh
+++ b/install/setup.sh
@@ -78,7 +78,7 @@ configure_conjur
 
 configure_conjur(){
 #create CLI container
-sudo docker container run -d --name conjur-cli --network conjur --restart=always --entrypoint "" cyberark/conjur-cli:5 sleep infinity
+sudo docker container run -d --name conjur-cli --network conjur --restart=always --entrypoint '' cyberark/conjur-cli:5 sleep infinity
 
 #set the company name in the cli-retrieve-password.sh script
 sed -i "s/master_name=.*/master_name=$master_name/g" policy/cli-retrieve-password.sh


### PR DESCRIPTION
Some docker engines misread the " and it won't allow the container to start. Changing to ' allows this to work.